### PR TITLE
Create Main, Form, Json and Textarea components

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -2,8 +2,8 @@ import React, { Component } from "react";
 import "./App.scss";
 //import sample from "./services/sample.json";
 import sample_2 from "./services/sample_2.json";
-import Preview from "./components/Preview";
 import Header from "./components/Header";
+import Main from "./components/Main";
 import Footer from "./components/Footer";
 
 class App extends Component {
@@ -25,9 +25,7 @@ class App extends Component {
     return (
       <div className="App">
         <Header />
-        <main className="main">
-          <Preview sample={sample} handlePrintBtn={this.handlePrintBtn} />
-        </main>
+        <Main sample={sample} handlePrintBtn={this.handlePrintBtn} />
         <Footer />
       </div>
     );

--- a/src/App.js
+++ b/src/App.js
@@ -14,10 +14,17 @@ class App extends Component {
     };
 
     this.handlePrintBtn = this.handlePrintBtn.bind(this);
+    this.handleJsonText = this.handleJsonText.bind(this);
   }
 
   handlePrintBtn() {
     window.print();
+  }
+
+  handleJsonText(event) {
+    const currentValue = event.currentTarget.value;
+    const parsedValue = JSON.parse(currentValue);
+    this.setState({ sample: parsedValue });
   }
 
   render() {
@@ -25,7 +32,11 @@ class App extends Component {
     return (
       <div className="App">
         <Header />
-        <Main sample={sample} handlePrintBtn={this.handlePrintBtn} />
+        <Main
+          sample={sample}
+          handlePrintBtn={this.handlePrintBtn}
+          handleJsonText={this.handleJsonText}
+        />
         <Footer />
       </div>
     );

--- a/src/components/Form/index.js
+++ b/src/components/Form/index.js
@@ -5,7 +5,7 @@ class Form extends Component {
   render() {
     return (
       <section className="form__wrapper">
-        Form
+        <h2 className="form__title">Here will be the form</h2>
       </section>
     );
   }

--- a/src/components/Form/index.js
+++ b/src/components/Form/index.js
@@ -1,0 +1,14 @@
+import React, { Component } from 'react';
+//import PropTypes from 'prop-types';
+
+class Form extends Component {
+  render() {
+    return (
+      <section className="form__wrapper">
+        Form
+      </section>
+    );
+  }
+}
+
+export default Form;

--- a/src/components/Json/index.js
+++ b/src/components/Json/index.js
@@ -14,8 +14,9 @@ class Json extends Component {
           modifying it, your new JSON will be here waiting to be copied back!
         </p>
         <Textarea
-          name="json"
-          value={parsedSample}
+          labelContent="JSON code"
+          textName="json"
+          textValue={parsedSample}
           handleTextChange={handleJsonText}
         />
       </section>

--- a/src/components/Json/index.js
+++ b/src/components/Json/index.js
@@ -1,0 +1,31 @@
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import Textarea from "../Textarea";
+
+class Json extends Component {
+  render() {
+    const { sample, handleJsonText } = this.props;
+    const parsedSample = JSON.stringify(sample);
+    return (
+      <section className="json__wrapper">
+        <h2 className="json__title">JSON viewer</h2>
+        <p className="json__guidelines">
+          Paste here your JSON and check the CV created. When you're done
+          modifying it, your new JSON will be here waiting to be copied back!
+        </p>
+        <Textarea
+          name="json"
+          value={parsedSample}
+          handleTextChange={handleJsonText}
+        />
+      </section>
+    );
+  }
+}
+
+Json.propTypes = {
+  sample: PropTypes.object.isRequired,
+  handleJsonText: PropTypes.func.isRequired
+};
+
+export default Json;

--- a/src/components/Main/index.js
+++ b/src/components/Main/index.js
@@ -2,13 +2,15 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import Preview from "../Preview";
 import Form from "../Form";
+import Json from "../Json";
 
 class Main extends Component {
   render() {
-    const { sample, handlePrintBtn } = this.props;
+    const { sample, handlePrintBtn, handleJsonText } = this.props;
     return (
       <main className="main">
         <Form />
+        <Json sample={sample} handleJsonText={handleJsonText} />
         <Preview sample={sample} handlePrintBtn={handlePrintBtn} />
       </main>
     );
@@ -16,7 +18,9 @@ class Main extends Component {
 }
 
 Main.propTypes = {
-  sample: PropTypes.object.isRequired
+  sample: PropTypes.object.isRequired,
+  handlePrintBtn: PropTypes.func.isRequired,
+  handleJsonText: PropTypes.func.isRequired
 };
 
 export default Main;

--- a/src/components/Main/index.js
+++ b/src/components/Main/index.js
@@ -1,12 +1,14 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import Preview from "../Preview";
+import Form from "../Form";
 
 class Main extends Component {
   render() {
     const { sample, handlePrintBtn } = this.props;
     return (
       <main className="main">
+        <Form />
         <Preview sample={sample} handlePrintBtn={handlePrintBtn} />
       </main>
     );

--- a/src/components/Main/index.js
+++ b/src/components/Main/index.js
@@ -1,0 +1,20 @@
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import Preview from "../Preview";
+
+class Main extends Component {
+  render() {
+    const { sample, handlePrintBtn } = this.props;
+    return (
+      <main className="main">
+        <Preview sample={sample} handlePrintBtn={handlePrintBtn} />
+      </main>
+    );
+  }
+}
+
+Main.propTypes = {
+  sample: PropTypes.object.isRequired
+};
+
+export default Main;

--- a/src/components/Textarea/index.js
+++ b/src/components/Textarea/index.js
@@ -1,0 +1,10 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+const Textarea = ({ name }) => <textarea name={name} rows="8" cols="50" />;
+
+Textarea.propTypes = {
+  name: PropTypes.string.isRequired
+};
+
+export default Textarea;

--- a/src/components/Textarea/index.js
+++ b/src/components/Textarea/index.js
@@ -1,10 +1,20 @@
 import React from "react";
 import PropTypes from "prop-types";
 
-const Textarea = ({ name }) => <textarea name={name} rows="8" cols="50" />;
+const Textarea = ({ name, value, handleTextChange }) => (
+  <textarea
+    name={name}
+    value={value}
+    rows="8"
+    cols="50"
+    onChange={handleTextChange}
+  />
+);
 
 Textarea.propTypes = {
-  name: PropTypes.string.isRequired
+  name: PropTypes.string.isRequired,
+  value: PropTypes.string.isRequired,
+  handleTextChange: PropTypes.func.isRequired
 };
 
 export default Textarea;

--- a/src/components/Textarea/index.js
+++ b/src/components/Textarea/index.js
@@ -1,19 +1,24 @@
 import React from "react";
 import PropTypes from "prop-types";
 
-const Textarea = ({ name, value, handleTextChange }) => (
-  <textarea
-    name={name}
-    value={value}
-    rows="8"
-    cols="50"
-    onChange={handleTextChange}
-  />
+const Textarea = ({ labelContent, textName, textValue, handleTextChange }) => (
+  <label className="label" htmlFor={textName}>
+    {labelContent}
+    <textarea
+      name={textName}
+      value={textValue}
+      rows="8"
+      cols="50"
+      onChange={handleTextChange}
+    />
+  </label>
+
 );
 
 Textarea.propTypes = {
-  name: PropTypes.string.isRequired,
-  value: PropTypes.string.isRequired,
+  labelContent: PropTypes.string.isRequired,
+  textName: PropTypes.string.isRequired,
+  textValue: PropTypes.string.isRequired,
   handleTextChange: PropTypes.func.isRequired
 };
 


### PR DESCRIPTION
Hi @minamrp ! Can you review the work I've been doing?

First, I have created 4 components: Main, Form, Json and Textarea., with their propTypes. Next, I have instantiated each component where they correspond. The Form component is empty for now, but the Json component is already working as it should be:

I have instantiated a Textarea inside it, and controled it from the App state. To do so, I created a method in App to control the Textarea value (only for the Textarea in the Json component). In Json, because the prop sample is a JSON object, I've had to stringify it to pass it through to the Textarea. Only this way the JSON file can be painted here. Also, because the Textarea value is a string, but the sample stored in App state is a JSON, in the method that controls the Json Textarea value I had to parsed the Textarea value to JSON. Now, if you change the JSON data in the textarea in the webpage, you'll see in the React devTools that the App state changes accordingly.

By the way, to be able to see the Form and Json elements in the webpage, you'll have to hide the grey area that is behind the Cv preview. It's a ::before element in the <main> tag, just uncheck the position property in the devTools and it will disappear for the moment!