### PR TITLE
Fix tab bug by adding functions to set and get active tab from localStorage

### DIFF
--- a/src/components/Main/index.js
+++ b/src/components/Main/index.js
@@ -6,20 +6,32 @@ import Form from "../Form";
 import Json from "../Json";
 
 const tabs = [
-  { name: 'form', text: 'Form', linkTo: '/' },
-  { name: 'json', text: 'JSON editor', linkTo: '/json' },
-  { name: 'cv', text: 'CV viewer', linkTo: '/preview' }
-]
+  { name: "form", text: "Form", linkTo: "/" },
+  { name: "json", text: "JSON editor", linkTo: "/json" },
+  { name: "cv", text: "CV viewer", linkTo: "/preview" }
+];
 
 class Main extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      activeTab: 'form',
+      activeTab: this.getActiveTabFromLS()
+    };
+  }
+
+  getActiveTabFromLS() {
+    const localStorageActiveTab = localStorage.getItem("activeTab");
+    const localStorageJSON = JSON.parse(localStorageActiveTab);
+    if (!localStorageActiveTab) {
+      return "form";
+    } else {
+      return localStorageJSON;
     }
   }
+
   handleTabClick(newActiveTabName) {
-    this.setState({ activeTab: newActiveTabName })
+    this.setState({ activeTab: newActiveTabName });
+    localStorage.setItem("activeTab", JSON.stringify(newActiveTabName));
   }
 
   render() {
@@ -79,16 +91,23 @@ class Main extends Component {
         <div className="preview__wrapper">
           <nav className="main__nav">
             <ul className="nav__list">
-              {tabs.map((tabItem, index) =>
-                <li key={index}
-                  className={`nav__link ${tabItem.name === this.state.activeTab ? 'active' : ''}`}
-                  onClick={(e) => this.handleTabClick(tabItem.name)}
+              {tabs.map((tabItem, index) => (
+                <li
+                  key={index}
+                  className={`nav__link ${
+                    tabItem.name === this.state.activeTab ? "active" : ""
+                  }`}
+                  onClick={e => this.handleTabClick(tabItem.name)}
                 >
-                  {tabItem.name === this.state.activeTab
-                    ? tabItem.text
-                    : <Link className="nav__link-route" to={tabItem.linkTo}>{tabItem.text}</Link>}
+                  {tabItem.name === this.state.activeTab ? (
+                    tabItem.text
+                  ) : (
+                    <Link className="nav__link-route" to={tabItem.linkTo}>
+                      {tabItem.text}
+                    </Link>
+                  )}
                 </li>
-              )}
+              ))}
             </ul>
           </nav>
           <Switch>


### PR DESCRIPTION
@maria-badanina @emma-martin @minamrp hi girls! There was a bug in the tab system and I just fixed it.

The problem was that if the user was on the CV page, and then reloaded the page, the tab changed to Form because it was the default one, but the page was still in CV. Now we only allow the tab to be a link if it's not the active tab, so the user couldn't change to Form because it was the active tab in Main.js state, and therefore couldn't be a link. I fixed this issue by saving the active tab in localStorage in the same function that controls the tab click. Moreover, there's a new function that picks up the active tab from LS and is called in Main.js state to save this value in activeTab. This way, when the user reloads the page, the tab will correspond to the page where it was before reloading!

There's still a minor bug: if localStorage is deleted, form will be the default activeTab, so if the user reloads the page there will be the same problem as before. I think it's not very likely that the user will delete the LS during the same session, so this wouldn't be urgent to solve, but if you have any ideas to fix it let me know!!